### PR TITLE
Using ransac with resolution information now.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf
 )
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -fopenmp -O2 -mtune=native")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -fopenmp -O2 -march=native")
 
 ## System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS system)

--- a/src/Localization.cpp
+++ b/src/Localization.cpp
@@ -18,39 +18,39 @@
 namespace ohm_tsd_slam
 {
 
-Localization::Localization(obvious::TsdGrid* grid, ThreadMapping* mapper, ros::NodeHandle& nh, const double xOffFactor, const double yOffFactor, const bool ransac):
-        _gridOffSetX(-1.0 * grid->getCellsX() * grid->getCellSize() * xOffFactor),
-        _gridOffSetY(-1.0 * grid->getCellsY() * grid->getCellSize() * yOffFactor)
+Localization::Localization(obvious::TsdGrid* grid, ThreadMapping* mapper, ros::NodeHandle& nh, const double xOffFactor, const double yOffFactor, const bool ransac) :
+    _gridOffSetX(-1.0 * grid->getCellsX() * grid->getCellSize() * xOffFactor), _gridOffSetY(-1.0 * grid->getCellsY()
+        * grid->getCellSize() * yOffFactor)
 {
   ros::NodeHandle prvNh("~");
-  _mapper           = mapper;
-  _grid             = grid;
-  _ransac           = ransac;
-  _scene            = NULL;
-  _modelCoords      = NULL;
-  _modelNormals     = NULL;
+  _mapper = mapper;
+  _grid = grid;
+  _ransac = ransac;
+  _scene = NULL;
+  _modelCoords = NULL;
+  _modelNormals = NULL;
 
   double distFilterMax = 0.0;
   double distFilterMin = 0.0;
-  int icpIterations    = 0;
+  int icpIterations = 0;
 
   prvNh.param<double>("dist_filter_max", distFilterMax, 0.2);
   prvNh.param<double>("dist_filter_min", distFilterMin, 0.01);
-  prvNh.param<int>   ("icp_iterations",     icpIterations, 20);
+  prvNh.param<int>("icp_iterations", icpIterations, 20);
 
-  _rayCaster        = new obvious::RayCastPolar2D();
-  _assigner         = new obvious::FlannPairAssignment(2);
-  _filterDist       = new obvious::DistanceFilter(distFilterMax, distFilterMin, icpIterations - 10);
+  _rayCaster = new obvious::RayCastPolar2D();
+  _assigner = new obvious::FlannPairAssignment(2);
+  _filterDist = new obvious::DistanceFilter(distFilterMax, distFilterMin, icpIterations - 10);
   _filterReciprocal = new obvious::ReciprocalFilter();
-  _estimator        = new obvious::ClosedFormEstimator2D();
-  prvNh.param<double>("reg_trs_max",     _trnsMax, TRNS_THRESH);
-  prvNh.param<double>("reg_sin_rot_max", _rotMax,  ROT_THRESH);
-  _lastPose         = new obvious::Matrix(3, 3);
-  _xOffFactor       = xOffFactor;
-  _yOffFactor       = yOffFactor;
+  _estimator = new obvious::ClosedFormEstimator2D();
+  prvNh.param<double>("reg_trs_max", _trnsMax, TRNS_THRESH);
+  prvNh.param<double>("reg_sin_rot_max", _rotMax, ROT_THRESH);
+  _lastPose = new obvious::Matrix(3, 3);
+  _xOffFactor = xOffFactor;
+  _yOffFactor = yOffFactor;
 
   //configure ICP
-  _filterBounds     = new obvious::OutOfBoundsFilter2D(grid->getMinX(), grid->getMaxX(), grid->getMinY(), grid->getMaxY());
+  _filterBounds = new obvious::OutOfBoundsFilter2D(grid->getMinX(), grid->getMaxX(), grid->getMinY(), grid->getMaxY());
   _assigner->addPreFilter(_filterBounds);
   _assigner->addPostFilter(_filterDist);
   _assigner->addPostFilter(_filterReciprocal);
@@ -63,15 +63,15 @@ Localization::Localization(obvious::TsdGrid* grid, ThreadMapping* mapper, ros::N
   std::string tfBaseFrameId;
   std::string tfChildFrameId;
 
-  prvNh.param        ("pose_topic",     poseTopic, std::string("pose"));
-  prvNh.param        ("tf_base_frame",  tfBaseFrameId, std::string("/map"));
-  prvNh.param        ("tf_child_frame", tfChildFrameId, std::string("laser"));
+  prvNh.param("pose_topic", poseTopic, std::string("pose"));
+  prvNh.param("tf_base_frame", tfBaseFrameId, std::string("/map"));
+  prvNh.param("tf_child_frame", tfChildFrameId, std::string("laser"));
 
-  _posePub = nh.advertise<geometry_msgs::PoseStamped>(poseTopic, 1);
+  _posePub = nh.advertise < geometry_msgs::PoseStamped > (poseTopic, 1);
 
   _poseStamped.header.frame_id = tfBaseFrameId;
-  _tf.frame_id_                = tfBaseFrameId;
-  _tf.child_frame_id_          = tfChildFrameId;
+  _tf.frame_id_ = tfBaseFrameId;
+  _tf.child_frame_id_ = tfChildFrameId;
 }
 
 Localization::~Localization()
@@ -85,11 +85,11 @@ Localization::~Localization()
   delete _icp;
   delete _lastPose;
   if(_modelCoords)
-    delete [] _modelCoords;
+    delete[] _modelCoords;
   if(_modelNormals)
-    delete [] _modelNormals;
+    delete[] _modelNormals;
   if(_scene)
-    delete [] _scene;
+    delete[] _scene;
 }
 
 void Localization::localize(obvious::SensorPolar2D* sensor)
@@ -98,10 +98,10 @@ void Localization::localize(obvious::SensorPolar2D* sensor)
 
   if(!_scene)
   {
-    _scene        = new double[size * 2];
-    _modelCoords  = new double[size * 2];
+    _scene = new double[size * 2];
+    _modelCoords = new double[size * 2];
     _modelNormals = new double[size * 2];
-    *_lastPose    = sensor->getTransformation();
+    *_lastPose = sensor->getTransformation();
   }
 
   // reconstruction
@@ -117,13 +117,12 @@ void Localization::localize(obvious::SensorPolar2D* sensor)
   obvious::Matrix P = sensor->getTransformation();
   _filterBounds->setPose(&P);
 
-  obvious::Matrix M( modelSize / 2, 2, _modelCoords);
-  obvious::Matrix N( modelSize / 2, 2, _modelNormals);
+  obvious::Matrix M(modelSize / 2, 2, _modelCoords);
+  obvious::Matrix N(modelSize / 2, 2, _modelNormals);
 
   size = sensor->dataToCartesianVector(_scene);
 
   obvious::Matrix S(size / 2, 2, _scene);
-
 
   obvious::Matrix T44(4, 4);
   T44.setIdentity();
@@ -132,7 +131,7 @@ void Localization::localize(obvious::SensorPolar2D* sensor)
   if(_ransac)
   {
     RansacMatching ransac;
-    obvious::Matrix T = ransac.match(&M, &S, M_PI/4, sensor->getAngularResolution());
+    obvious::Matrix T = ransac.match(&M, &S, M_PI / 4, sensor->getAngularResolution());
     T.invert();
     T44(0, 0) = T(0, 0);
     T44(0, 1) = T(0, 1);
@@ -152,15 +151,16 @@ void Localization::localize(obvious::SensorPolar2D* sensor)
   T.invert();
 
   // analyze registration result
-  double deltaX = T(0,2);
-  double deltaY = T(1,2);
+  double deltaX = T(0, 2);
+  double deltaY = T(1, 2);
   double trnsAbs = std::sqrt(deltaX * deltaX + deltaY * deltaY);
   double deltaPhi = this->calcAngle(&T);
   _tf.stamp_ = ros::Time::now();
 
   if(deltaY > 0.5 || (trnsAbs > _trnsMax) || std::fabs(std::sin(deltaPhi)) > _rotMax)
   {
-    cout << "Registration error - deltaY=" << deltaY << " trnsAbs=" << trnsAbs << " sin(deltaPhi)=" << sin(deltaPhi) << endl;
+    cout << "Registration error - deltaY=" << deltaY << " trnsAbs=" << trnsAbs << " sin(deltaPhi)=" << sin(deltaPhi)
+        << endl;
     // localization error broadcast invalid tf
 
     _poseStamped.header.stamp = ros::Time::now();
@@ -187,7 +187,7 @@ void Localization::localize(obvious::SensorPolar2D* sensor)
     double curTheta = this->calcAngle(&curPose);
     double posX = curPose(0, 2) + _gridOffSetX;
     double posY = curPose(1, 2) + _gridOffSetY;
-    _poseStamped.header.stamp    = ros::Time::now();
+    _poseStamped.header.stamp = ros::Time::now();
     _poseStamped.pose.position.x = posX;
     _poseStamped.pose.position.y = posY;
     _poseStamped.pose.position.z = 0.0;
@@ -213,24 +213,24 @@ void Localization::localize(obvious::SensorPolar2D* sensor)
 
 double Localization::calcAngle(obvious::Matrix* T)
 {
-  double angle          = 0.0;
-  const double ARCSIN   = asin((*T)(1,0));
-  const double ARCSINEG = asin((*T)(0,1));
-  const double ARCOS    = acos((*T)(0,0));
+  double angle = 0.0;
+  const double ARCSIN = asin((*T)(1, 0));
+  const double ARCSINEG = asin((*T)(0, 1));
+  const double ARCOS = acos((*T)(0, 0));
   if((ARCSIN > 0.0) && (ARCSINEG < 0.0))
     angle = ARCOS;
   else if((ARCSIN < 0.0) && (ARCSINEG > 0.0))
     angle = 2.0 * M_PI - ARCOS;
-  return(angle);
+  return (angle);
 }
 
 bool Localization::isPoseChangeSignificant(obvious::Matrix* lastPose, obvious::Matrix* curPose)
 {
-  double deltaX   = (*curPose)(0, 2) - (*lastPose)(0, 2);
-  double deltaY   = (*curPose)(1, 2) - (*lastPose)(1, 2);
+  double deltaX = (*curPose)(0, 2) - (*lastPose)(0, 2);
+  double deltaY = (*curPose)(1, 2) - (*lastPose)(1, 2);
   double deltaPhi = this->calcAngle(curPose) - this->calcAngle(lastPose);
-  deltaPhi        = fabs(sin(deltaPhi));
-  double trnsAbs  = sqrt(deltaX * deltaX + deltaY * deltaY);
+  deltaPhi = fabs(sin(deltaPhi));
+  double trnsAbs = sqrt(deltaX * deltaX + deltaY * deltaY);
 
   return (deltaPhi > ROT_MIN) || (trnsAbs > TRNS_MIN);
 }

--- a/src/Localization.cpp
+++ b/src/Localization.cpp
@@ -121,6 +121,7 @@ void Localization::localize(obvious::SensorPolar2D* sensor)
   obvious::Matrix N( modelSize / 2, 2, _modelNormals);
 
   size = sensor->dataToCartesianVector(_scene);
+
   obvious::Matrix S(size / 2, 2, _scene);
 
 
@@ -131,7 +132,7 @@ void Localization::localize(obvious::SensorPolar2D* sensor)
   if(_ransac)
   {
     RansacMatching ransac;
-    obvious::Matrix T = ransac.match(&M, &S);
+    obvious::Matrix T = ransac.match(&M, &S, M_PI/4, sensor->getAngularResolution());
     T.invert();
     T44(0, 0) = T(0, 0);
     T44(0, 1) = T(0, 1);


### PR DESCRIPTION
Localization.cpp uses RANSAC matching with resolution information. This information is used by RansacMatching in obviously to massively increase the speed of the registration.
Ransac (50 Iterations, PI/4) + ICP(25 Iterations) --> 25 HZ on Intel i5 (NCT Parcour bagfile)